### PR TITLE
Fix Discord Rich Presence

### DIFF
--- a/app.ytmdesktop.ytmdesktop.yml
+++ b/app.ytmdesktop.ytmdesktop.yml
@@ -16,6 +16,7 @@ finish-args:
   - --device=dri
   - --own-name=org.mpris.MediaPlayer2.youtubemusic
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/discord-ipc-0
 modules:
   - name: ytmdesktop
     buildsystem: simple


### PR DESCRIPTION
This fixes the rich presence for Discord, when Discord is installed directly to the system instead of as a flatpak.