### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/app.ytmdesktop.ytmdesktop.desktop
+++ b/app.ytmdesktop.ytmdesktop.desktop
@@ -6,3 +6,4 @@ Type=Application
 Terminal=false
 Categories=AudioVideo;Utility
 Exec=start-ytmdesktop %U
+StartupWMClass=YouTube Music Desktop App


### PR DESCRIPTION
This allows the desktop icon to be linked to the launched application.

On Wayland this makes the icon behave correctly instead of having YTMDesktop spawn as a separate icon in the task tray.