### PR TITLE
Fix Wayland Support / Misc Fixes / Update to FreeDesktop Runtime 25.08

### DIFF
--- a/app.ytmdesktop.ytmdesktop.desktop
+++ b/app.ytmdesktop.ytmdesktop.desktop
@@ -7,3 +7,4 @@ Type=Application
 Terminal=false
 Categories=AudioVideo;Utility
 Exec=start-ytmdesktop %U
+StartupWMClass=YouTube Music Desktop App

--- a/app.ytmdesktop.ytmdesktop.metainfo.xml
+++ b/app.ytmdesktop.ytmdesktop.metainfo.xml
@@ -54,14 +54,14 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="v2.0.10" date="2025-09-04">
-      <description></description>
+    <release version="v2.0.10" type="stable" date="2025-09-04">
+      <url>https://github.com/ytmdesktop/ytmdesktop/releases/tag/v2.0.10/</url>
     </release>
-    <release version="v2.0.9" date="2025-06-05">
-      <description/>
+    <release version="v2.0.9" type="stable" date="2025-06-05">
+      <url>https://github.com/ytmdesktop/ytmdesktop/releases/tag/v2.0.9/</url>
     </release>
-    <release version="v2.0.8" date="2025-03-19">
-      <description/>
+    <release version="v2.0.8" type="stable" date="2025-03-19">
+      <url>https://github.com/ytmdesktop/ytmdesktop/releases/tag/v2.0.8/</url>
     </release>
     <release version="v2.0.5" type="stable" date="2024-05-06">
       <url>https://github.com/ytmdesktop/ytmdesktop/releases/tag/v2.0.5/</url>

--- a/app.ytmdesktop.ytmdesktop.yml
+++ b/app.ytmdesktop.ytmdesktop.yml
@@ -21,6 +21,8 @@ finish-args:
   # Allow access to MPRIS controls.
   # Broken until https://github.com/ytmdesktop/ytmdesktop/pull/1359 is merged upstream.
   - --own-name=org.mpris.MediaPlayer2.ytmdesktop
+  # Hack to get MPRIS working until above name is used.
+  - --own-name=org.mpris.MediaPlayer2.chromium.instance13
   # Allow talking to Flatpak and native discord sockets.
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0

--- a/app.ytmdesktop.ytmdesktop.yml
+++ b/app.ytmdesktop.ytmdesktop.yml
@@ -1,6 +1,6 @@
 app-id: app.ytmdesktop.ytmdesktop
 runtime: org.freedesktop.Platform
-runtime-version: &runtime-version '23.08'
+runtime-version: &runtime-version '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: *runtime-version

--- a/app.ytmdesktop.ytmdesktop.yml
+++ b/app.ytmdesktop.ytmdesktop.yml
@@ -76,7 +76,7 @@ modules:
           - WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
           - if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}"
             ]] then
-          - FLAGS="--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto"
+          - FLAGS="--ozone-platform=wayland"
           - fi
           - for i in {0..9}; do
           - test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;


### PR DESCRIPTION
This fixes the currently broken Wayland support for the Flatpak, which results in crashes on Distros that use it by default, as well as updates the FreeDesktop Runtime to 25.08.

With this I have also added in the fix from https://github.com/flathub/app.ytmdesktop.ytmdesktop/pull/24 as that is related to fixes to Wayland support, as well as fixing MPRIS support until YTMDesktop's MPRIS support is properly merged into a release build. Should fix https://github.com/flathub/app.ytmdesktop.ytmdesktop/issues/1

Make sure when testing future releases you also check under Wayland, just in case something breaks with newer updates.