### PR TITLE
Add access to password stores via d-bus talks

### DIFF
--- a/app.ytmdesktop.ytmdesktop.yml
+++ b/app.ytmdesktop.ytmdesktop.yml
@@ -30,6 +30,9 @@ finish-args:
   - --talk-name=org.ayatana
   # Allow access to appindicator icons on KDE
   - --talk-name=org.kde.StatusNotifierWatcher
+  # Allow access to KWallet/gnome-keyring/KeePassXC etc for Electron safeStorage
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd6
 modules:
   - name: ytmdesktop
     buildsystem: simple


### PR DESCRIPTION
There are features in YTMDesktop that require the safeStorage feature of
Electron. Specifically the "Companion server" and "Last.fm scrobbling".
Without access to these talk-names, Electron will say that safeStorage
is unavailable, and so these features are unavailable.

Examples of users raising this issue are ytmdesktop/ytmdesktop#1186 and
ytmdesktop/ytmdesktop#1428.
